### PR TITLE
クリティカルコールの閾値を選択できるように修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@
           <select id="cc-lower-limit" v-model="state.ccLowerLimit">
             <option value="0">-</option>
             <option
-              v-for="lowerLimit in 10"
+              v-for="lowerLimit in 11"
               :key="`ccll-${lowerLimit}`"
               :value="lowerLimit + 1"
             >
@@ -36,7 +36,7 @@
           <select id="cc-upper-limit" v-model="state.ccUpperLimit">
             <option value="0">-</option>
             <option
-              v-for="upperLimit in 10"
+              v-for="upperLimit in 11"
               :key="`ccul-${upperLimit}`"
               :value="upperLimit + 1"
             >

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,37 @@
       <input v-model="state.id" placeholder="edit me" />
       <button @click="onButtonClicked">クリップボードにコピー</button>
     </div>
+    <div id="utakaze-cc">
+      <p>クリティカルコールを適用するダイスプールの範囲</p>
+      <ul id="cc-settnigs-list">
+        <li id="cc-lower-item">
+          <select id="cc-lower-limit" v-model="state.ccLowerLimit">
+            <option value="0">-</option>
+            <option
+              v-for="lowerLimit in 10"
+              :key="`ccll-${lowerLimit}`"
+              :value="lowerLimit + 1"
+            >
+              {{ lowerLimit + 1 }}
+            </option>
+          </select>
+          以上でクリティカルコールを適用する
+        </li>
+        <li id="cc-upper-item">
+          <select id="cc-upper-limit" v-model="state.ccUpperLimit">
+            <option value="0">-</option>
+            <option
+              v-for="upperLimit in 10"
+              :key="`ccul-${upperLimit}`"
+              :value="upperLimit + 1"
+            >
+              {{ upperLimit + 1 }}
+            </option>
+          </select>
+          以下でクリティカルコールを適用する
+        </li>
+      </ul>
+    </div>
     <div id="result">
       <div v-if="state.hasError">
         <p>
@@ -47,6 +78,10 @@ import { UtakazeResponse } from "@/types/utakaze";
 import { convUtakaze, utakaze2Ccfolia } from "@/modules/utakaze";
 
 interface State {
+  /** クリティカルコールのダイスプール下限値 */
+  ccLowerLimit: number;
+  /** クリティカルコールのダイスプール上限値 */
+  ccUpperLimit: number;
   hasError: boolean;
   isUnsupportedSystem: boolean;
   id?: number;
@@ -58,6 +93,8 @@ export default defineComponent({
   name: "App",
   setup() {
     const state = reactive<State>({
+      ccLowerLimit: 2,
+      ccUpperLimit: 5,
       hasError: false,
       isUnsupportedSystem: false,
     });
@@ -75,6 +112,10 @@ export default defineComponent({
     const _setUtakazeToClipboard = (res: UtakazeResponse) => {
       const convData = convUtakaze(res);
       state.charaName = convData.name;
+      convData.ccLimit = {
+        lower: state.ccLowerLimit,
+        upper: state.ccUpperLimit,
+      };
       const piece = utakaze2Ccfolia(convData);
       _copyToClipboard(JSON.stringify(piece));
     };

--- a/src/modules/utakaze.ts
+++ b/src/modules/utakaze.ts
@@ -17,54 +17,68 @@ function createChatParret(chara: UtakazeCharacter): string {
     "{愛情}UK 【愛情】"
   );
 
-  chatParret.push("=== 戦闘技能判定")
-  let battle = "({勇気}+{戦い})UK 【勇気+戦い】";
-  if (chara.params.battle < 5) {
-    battle = "({勇気}+{戦い})UK@{龍} 【CC:勇気+戦い】";
-  }
-  chatParret.push(`${battle}${chara.equip.melee}`);
-  let hunt = "({知恵}+{狩り})UK 【知恵+狩り】";
-  if (chara.params.hunt < 5) {
-    hunt = "({知恵}+{狩り})UK@{龍} 【CC:知恵+狩り】";
-  }
-  chatParret.push(`${hunt}${chara.equip.ranged}`);
-  let sing = "({愛情}+{歌})UK 【愛情+歌】";
-  if (chara.params.sing < 5) {
-    sing = "({愛情}+{歌})UK@{龍} 【CC:愛情+歌】";
-  }
-  chatParret.push(`${sing}${chara.equip.instrument}`);
+  const needCriticalCall = (dicePool: number) => {
+    // 上限・下限ともに指定がなければクリティカルコールは適用しない
+    if (chara.ccLimit.lower === 0 && chara.ccLimit.upper === 0) {
+      return false;
+    }
+    // 下限のみ未指定ならば、上限値以下のダイスプールで CC を適用
+    if (chara.ccLimit.lower === 0) {
+      return dicePool <= chara.ccLimit.upper;
+    }
+    // 上限のみ未指定ならば、下限値以上の大きいダイスプールで CC を適用
+    if (chara.ccLimit.upper === 0) {
+      return chara.ccLimit.lower <= dicePool;
+    }
+    // 下限値〜上限値を満たすダイスプールで CC を適用
+    return chara.ccLimit.lower <= dicePool && dicePool <= chara.ccLimit.upper;
+  };
 
-  chatParret.push("=== 探索技能判定");
-  let adventure = "({勇気}+{冒険})UK 【勇気+冒険】";
-  if (chara.params.adventure < 5) {
-    adventure = "({勇気}+{冒険})UK@{龍} 【CC:勇気+冒険】";
-  }
-  chatParret.push(adventure);
-  let ride = "({勇気}+{騎乗})UK 【勇気+騎乗】";
-  if (chara.params.ride < 5) {
-    ride = "({勇気}+{騎乗})UK@{龍} 【CC:勇気+騎乗】";
-  }
-  chatParret.push(ride);
-  let sense = "({知恵}+{感覚})UK 【知恵+感覚】";
-  if (chara.params.sense < 5) {
-    sense = "({知恵}+{感覚})UK@{龍} 【CC:知恵+感覚】";
-  }
-  chatParret.push(sense);
-  let knowledge = "({知恵}+{学問})UK 【知恵+学問】";
-  if (chara.params.knowledge < 5) {
-    knowledge = "({知恵}+{学問})UK@{龍} 【CC:知恵+学問】";
-  }
-  chatParret.push(knowledge);
-  let persuade = "({愛情}+{説得})UK 【愛情+説得】";
-  if (chara.params.persuade < 5) {
-    persuade = "({愛情}+{説得})UK@{龍} 【CC:愛情+説得】";
-  }
-  chatParret.push(persuade);
-  let heart = "({愛情}+{心話})UK 【愛情+心話】";
-  if (chara.params.heart < 5) {
-    heart = "({愛情}+{心話})UK@{龍} 【CC:愛情+心話】";
-  }
-  chatParret.push(heart);
+  // 戦闘系の技能値に関するチャットパレット
+  const battle = needCriticalCall(chara.params.battle)
+    ? "({勇気}+{戦い})UK@{龍} 【CC:勇気+戦い】"
+    : "({勇気}+{戦い}) 【勇気+戦い】";
+  const hunt = needCriticalCall(chara.params.hunt)
+    ? "({知恵}+{狩り})UK@{龍} 【CC:知恵+狩り】"
+    : "({知恵}+{狩り})UK 【知恵+狩り】";
+  const sing = needCriticalCall(chara.params.sing)
+    ? "({愛情}+{歌})UK@{龍} 【CC:愛情+歌】"
+    : "({愛情}+{歌})UK 【愛情+歌】";
+  chatParret.push(
+    "=== 戦闘技能判定",
+    `${battle}${chara.equip.melee}`, // 勇気+戦い <近接武器>
+    `${hunt}${chara.equip.ranged}`, // 知恵+狩り <遠隔武器>
+    `${sing}${chara.equip.instrument}` // 愛情+歌 <楽器>
+  );
+
+  // 探索系の技能値に関するチャットパレット
+  const adventure = needCriticalCall(chara.params.adventure)
+    ? "({勇気}+{冒険})UK@{龍} 【CC:勇気+冒険】"
+    : "({勇気}+{冒険})UK 【勇気+冒険】";
+  const ride = needCriticalCall(chara.params.ride)
+    ? "({勇気}+{騎乗})UK@{龍} 【CC:勇気+騎乗】"
+    : "({勇気}+{騎乗})UK 【勇気+騎乗】";
+  const sense = needCriticalCall(chara.params.sense)
+    ? "({知恵}+{感覚})UK@{龍} 【CC:知恵+感覚】"
+    : "({知恵}+{感覚})UK 【知恵+感覚】";
+  const knowledge = needCriticalCall(chara.params.knowledge)
+    ? "({知恵}+{学問})UK@{龍} 【CC:知恵+学問】"
+    : "({知恵}+{学問})UK 【知恵+学問】";
+  const persuade = needCriticalCall(chara.params.persuade)
+    ? "({愛情}+{説得})UK@{龍} 【CC:愛情+説得】"
+    : "({愛情}+{説得})UK 【愛情+説得】";
+  const heart = needCriticalCall(chara.params.heart)
+    ? "({愛情}+{心話})UK@{龍} 【CC:愛情+心話】"
+    : "({愛情}+{心話})UK 【愛情+心話】";
+  chatParret.push(
+    "=== 探索技能判定",
+    adventure, // 勇気+冒険
+    ride, // 勇気+騎乗
+    sense, // 知恵+感覚
+    knowledge, // 知恵+学問
+    persuade, // 愛情+説得
+    heart // 愛情+心話
+  );
 
   return chatParret.join("\n");
 }
@@ -183,5 +197,9 @@ export function convUtakaze(data: UtakazeResponse): UtakazeCharacter {
       instrument: data.tokushu_buki,
     },
     items: items,
+    ccLimit: {
+      lower: 2,
+      upper: 5,
+    },
   };
 }

--- a/src/types/utakaze.ts
+++ b/src/types/utakaze.ts
@@ -53,6 +53,8 @@ export interface UtakazeCharacter {
   };
   /** リュックサックの中身 */
   items: { name: string; desc: string }[];
+  /** クリティカルコール適用の値域 */
+  ccLimit: { lower: number; upper: number };
 }
 
 /** キャラクター保管所から取得するデータ */


### PR DESCRIPTION
## 概要

表題の通りです。
ウタカゼは能力値の最大が 6、技能値の最大が 6 のため、2 ~ 12 を取り得る値として設定しました。
別種族の場合や、特技による加算などは今後レベルアップブックで遊んでいく中で追加します

## 動作確認

### 以下のようなセレクタを追加

<img width="395" alt="スクリーンショット 2021-09-25 15 21 20" src="https://user-images.githubusercontent.com/18107179/134761062-983c6aad-24be-43a5-849d-97d8c8f08873.png">

### 数値を適当に 2 ~ 20 まで設定できるように実装

<img width="454" alt="スクリーンショット 2021-09-25 15 21 25" src="https://user-images.githubusercontent.com/18107179/134761063-f850788d-a2d0-4897-a10a-f588f347ff09.png">

